### PR TITLE
Check for window global context (window.ko)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ## How to use
 
-Right click on a page that runs KnockoutJS and press the "KO Context Hover" option to activate the panel. Shortcuts for controlling mouse pointer following/live context data are present at the top of the panel.
+Right click on a page that runs KnockoutJS and press the "KO Context Hover" option to activate the panel. Shortcuts for controlling mouse pointer following (`shift` + `1`)/live (`shift` + `2`) context data are present at the top of the panel.
 
 <center>
 

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,7 @@
 
   "web_accessible_resources": [
     "markup/panel.html",
+    "scripts/bootstrap.js",
     "scripts/ko-context-hover.js",
     "reference-binding-handlers/ko.bindingHandlers.kchHoverClass.js",
     "reference-binding-handlers/ko.bindingHandlers.kchLet.js"

--- a/reference-binding-handlers/ko.bindingHandlers.kchHoverClass.js
+++ b/reference-binding-handlers/ko.bindingHandlers.kchHoverClass.js
@@ -1,4 +1,6 @@
-﻿(function (ko) {
+﻿import { ko } from "./../scripts/bootstrap.js";
+
+(function (ko) {
 
 	var kchHoverClassBootstrap = function (ko) {
 
@@ -34,11 +36,9 @@
 
 	if (ko) {
 		kchHoverClassBootstrap(ko)
-	} else if (typeof requirejs !== "undefined") {
-		// Attempt to load Knockout as a RequireJS module
-		requirejs(["knockout"], function (knockoutjs) {
-			kchHoverClassBootstrap(knockoutjs);
-		});
+	} else {
+		// bootstrapKnockoutApi could not found any instances, aborting...
+        return
 	}
 
-})(window.ko || this.ko);
+})(ko);

--- a/reference-binding-handlers/ko.bindingHandlers.kchLet.js
+++ b/reference-binding-handlers/ko.bindingHandlers.kchLet.js
@@ -1,3 +1,5 @@
+import { ko } from "./../scripts/bootstrap.js";
+
 (function (ko) {
 
     var kchLetBootstrap = function (ko) {
@@ -23,11 +25,9 @@
 
     if (ko) {
         kchLetBootstrap(ko)
-    } else if (typeof requirejs !== "undefined") {
-        // Attempt to load Knockout as a RequireJS module
-        requirejs(["knockout"], function (knockoutjs) {
-            kchLetBootstrap(knockoutjs);
-        });
+    } else {
+        // bootstrapKnockoutApi could not found any instances, aborting...
+        return
     }
 
-})(window.ko || this.ko);
+})(ko);

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -1,0 +1,57 @@
+/**
+ * Searches and returns knockout instance
+ * 
+ * @returns {object|undefined} knockout instance if found
+ */
+const bootstrapKnockoutApi = () => {
+    /**
+     * Print to console a disclaimer that
+     * no knockout instance was found on a page
+     */
+    function knockoutNotFoundDisclaimer() {
+        // knockout not found in any way
+        const label = "KnockoutContextHover: KnockoutJS not found"
+        console.group(label)
+        console.info(
+            "Knockoutjs was not found at global context (window.ko) nor through require.js (require.defined('ko')/require.defined('knockout')).",
+            "If you are using ECMA module imports, make sure knockout is available at global context with:"
+        )
+        console.log(`
+            import ko from "knockout
+            ...
+            window.ko = ko;
+        `)
+        console.groupEnd(label)
+    }
+
+    let ko = window.ko
+    if (ko) return ko
+
+    // requirejs snippet from
+    // https://github.com/timstuyckens/chromeextensions-knockoutjs/blob/master/pages/js/devtools.js
+    // try fetching ko with requirejs
+    if (typeof window.require === 'function') {
+        var isDefinedAvailable = typeof window.require.defined === 'function';
+        try {
+            if ((isDefinedAvailable && require.defined('ko')) || !isDefinedAvailable) {
+                ko = require('ko');
+            }
+        } catch (e) { /*ignore */ }
+        if (!ko) {
+            try {
+                if ((isDefinedAvailable && require.defined('knockout')) || !isDefinedAvailable) {
+                    ko = require('knockout');
+                }
+            } catch (e) { /*ignore */ }
+        }
+    }
+    if (ko) return ko
+
+    knockoutNotFoundDisclaimer()
+}
+
+/**
+ * load onse then return loaded instance or undefined (const ko),
+ * which is referred to in every dependant function
+ */
+export const ko = bootstrapKnockoutApi()

--- a/scripts/contentscript.js
+++ b/scripts/contentscript.js
@@ -1,7 +1,8 @@
 async function runScriptInPageScope(scriptPath) {
 
     let script = document.createElement('script');
-	script.setAttribute("type", "text/javascript");
+	// top level script module allows using ECMA-modiule imports
+    script.setAttribute("type", "module");
     script.setAttribute("src", await chrome.runtime.getURL(scriptPath));
 
 	script.onload = function () {
@@ -12,6 +13,17 @@ async function runScriptInPageScope(scriptPath) {
 
 }
 
+
+/**
+ * Fetches HTML from @see url
+ * on successfull fetch injects
+ * its contents into @see element DOM Node
+ * and calls for a function given in @see callback
+ * 
+ * @param {String} url 
+ * @param {Node} element 
+ * @param {CallableFunction} callback 
+ */
 async function loadHtml(url, element, callback) {
 
     const request = await fetch(url);
@@ -44,21 +56,31 @@ chrome.runtime.onMessage.addListener(async function (message, sender, callback) 
 
 		(document.body || document.documentElement).appendChild(contextHoverPanel);
 
-        await loadHtml(await chrome.runtime.getURL("markup/panel.html"), contextHoverPanel,
-			async function (status) {
+        await loadHtml(
+            await chrome.runtime.getURL("markup/panel.html"), contextHoverPanel,
+			/**
+             * Binds addon KO bindings and hoverable markup
+             * to a page if markup successfuly fetched
+             * 
+             * @param {Number} status Response HTTP code
+             */
+            async function (status) {
 
                 if (status === 200) {
 
                     // Load custom binding handlers and the main script
-                    await runScriptInPageScope('reference-binding-handlers/ko.bindingHandlers.kchLet.js');
-                    await runScriptInPageScope('reference-binding-handlers/ko.bindingHandlers.kchHoverClass.js');
-                    await runScriptInPageScope('scripts/ko-context-hover.js');
+                    await runScriptInPageScope(
+                        'reference-binding-handlers/ko.bindingHandlers.kchLet.js')
+                    await runScriptInPageScope(
+                        'reference-binding-handlers/ko.bindingHandlers.kchHoverClass.js')
+                    await runScriptInPageScope(
+                        'scripts/ko-context-hover.js')
 
                 } else {
-                    console.log('Failed to load markup for the \'knockout-context-hover\' browser extension.')
+                    console.error('Failed to load markup for the \'knockout-context-hover\' browser extension.')
                 }
-
-			});
+            }
+        );
 
 	}
 

--- a/scripts/ko-context-hover.js
+++ b/scripts/ko-context-hover.js
@@ -1,17 +1,15 @@
+// .js is required for matching web_accessible_resources module pattern
+import { ko } from "./bootstrap.js"
+
 (function (ko) {
-
     var kchBootstrap = function (ko) {
-
-        if (!ko) {
-            return;
-        }
-
+        /**
+         * Create a viewmodel for hoverable panel
+         * 
+         * @param {knockout<object>} ko 
+         * @returns {object} Knockout Context factory ViewModel
+         */
         let KoContextVm = function (ko) {
-
-            if (!ko) {
-                console.log('KnockoutContextHover: ko is not defined.');
-                return undefined;
-            }
 
             const self = this;
             let targetElement;
@@ -26,11 +24,24 @@
                 return undefined;
             }
 
+            /**
+             * Shorten a given string @see str if
+             * it exeeds @see max characters length
+             * 
+             * @param {String} str String to shorten
+             * @param {Number} max Maximum @see str length allowed
+             * before shortening it
+             * @returns 
+             */
             function truncate(str, max) {
                 return str.length > max ? str.substr(0, max - 4) + ' ...' : str;
             };
 
-            // Utility to ensure that the mouse isn't hovering the KO Context Hover panel itself to avoid recursion.
+            /**
+             * Utility to ensure that the mouse isn't hovering
+             * the KO Context Hover panel itself
+             * to avoid recursion.
+             */
             function checkTargetSelf(target) {
 
                 if (target === koContextHoverElement) {
@@ -108,6 +119,9 @@
 
             };
 
+            /**
+             * Triggers on change of selected by cursor element
+             */
             function refreshTargetElementKoData() {
 
                 if (targetElement) {
@@ -126,7 +140,6 @@
                     }
 
                     self.targetElementAttributes({
-
                         tagName: targetElement.tagName,
                         hasParentTarget: targetElement.parentNode !== null,
                         hasNextTarget: targetElement.nextSibling !== null || (targetElement.parentNode !== null && targetElement.parentNode.nextSibling !== null),
@@ -134,7 +147,6 @@
                         name: targetElement.name ? truncate(targetElement.name, 30) : undefined,
                         id: targetElement.id ? truncate(targetElement.id, 30) : undefined,
                         classList: classList ? truncate(classList.join(' '), 50) : undefined
-
                     });
 
                 } else {
@@ -144,6 +156,13 @@
 
             };
 
+            /**
+             * 
+             * @param {Element} newTargetElement New DOM Element at
+             * which apply monitoring
+             * if new element is found
+             * refresh its data with @see refreshTargetElementKoData
+             */
             function selectTargetElement(newTargetElement) {
 
                 if (newTargetElement && targetElement !== newTargetElement) {
@@ -546,12 +565,8 @@
 
     if (ko) {
         kchBootstrap(ko);
-    } else if (typeof requirejs !== "undefined") {
-        // Attempt to load Knockout as a RequireJS module
-        requirejs(["knockout"], function (knockoutjs) {
-            window.ko = knockoutjs;
-            kchBootstrap(knockoutjs);
-        });
+    } else {
+        // bootstrapKnockoutApi could not found any instances, aborting...
+        return
     }
-
-})(window.ko || this.ko);
+})(ko);


### PR DESCRIPTION
Hello, working with extension I got a use-case when KO is imported as ECMA module solely, so no window.ko. Here's a fix, a separate IIFE function checking for a global context and returning it to all dependant modules (binding handlers and panel factory viewmodel)
- [x] Added JSdoc at panel factory function